### PR TITLE
Reported Bug Fixes and Improvements

### DIFF
--- a/DSL/Resql/update-data-model-dataset-group.sql
+++ b/DSL/Resql/update-data-model-dataset-group.sql
@@ -1,5 +1,8 @@
 UPDATE models_metadata
 SET
     connected_dg_name = null,
-    connected_dg_id = null
+    connected_dg_id = null,
+    connected_dg_major_version = 0,
+    connected_dg_minor_version = 0,
+    connected_dg_patch_version = 0
 WHERE connected_dg_id = :id;

--- a/GUI/src/components/molecules/DataModelCard/index.tsx
+++ b/GUI/src/components/molecules/DataModelCard/index.tsx
@@ -113,30 +113,19 @@ const DataModelCard: FC<PropsWithChildren<DataModelCardProps>> = ({
 
         <div className="py-3">
           <div>
-            <div style={{
-              display: "flex",
-              alignItems: "center"
-            }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
               {t('dataModels.dataModelCard.datasetGroup') ?? ''}:
-              {datasetGroupName ?? <div style={{
-                width: "fit-content",
-                backgroundColor: "#FDEDED",
-                paddingLeft: "10px",
-                paddingRight: "10px",
-                paddingTop: "4px",
-                paddingBottom: "4px",
-                color: "#5F2120",
-                marginLeft: "10px"
-              }}>
-                Deleted
-              </div>}
+              {datasetGroupName ??<div style={{marginLeft:'5px'}}> <Label type="error">Deleted </Label></div>}
             </div>
             <p>
               {t('dataModels.dataModelCard.dgVersion') ?? ''}:{dgVersion}
             </p>
-
           </div>
-
 
           <p>
             {t('dataModels.dataModelCard.lastTrained') ?? ''}:{' '}

--- a/GUI/src/components/molecules/DataModelCard/index.tsx
+++ b/GUI/src/components/molecules/DataModelCard/index.tsx
@@ -112,13 +112,32 @@ const DataModelCard: FC<PropsWithChildren<DataModelCardProps>> = ({
         </div>
 
         <div className="py-3">
-          <p>
-            {t('dataModels.dataModelCard.datasetGroup') ?? ''}:
-            {datasetGroupName}
-          </p>
-          <p>
-            {t('dataModels.dataModelCard.dgVersion') ?? ''}:{dgVersion}
-          </p>
+          <div>
+            <div style={{
+              display: "flex",
+              alignItems: "center"
+            }}>
+              {t('dataModels.dataModelCard.datasetGroup') ?? ''}:
+              {datasetGroupName ?? <div style={{
+                width: "fit-content",
+                backgroundColor: "#FDEDED",
+                paddingLeft: "10px",
+                paddingRight: "10px",
+                paddingTop: "4px",
+                paddingBottom: "4px",
+                color: "#5F2120",
+                marginLeft: "10px"
+              }}>
+                Deleted
+              </div>}
+            </div>
+            <p>
+              {t('dataModels.dataModelCard.dgVersion') ?? ''}:{dgVersion}
+            </p>
+
+          </div>
+
+
           <p>
             {t('dataModels.dataModelCard.lastTrained') ?? ''}:{' '}
             {lastTrained && formatDate(new Date(lastTrained), 'D.M.yy-H:m')}

--- a/GUI/src/components/molecules/DataModelForm/index.tsx
+++ b/GUI/src/components/molecules/DataModelForm/index.tsx
@@ -59,14 +59,17 @@ const DataModelForm: FC<DataModelFormType> = ({
         </div>
       )}
 
-      {((type === 'configure' && dataModel?.dgId > 0) || type === 'create') &&
-      createOptions &&
-      !isLoading ? (
+      {((type === 'configure') || type === 'create') &&
+        createOptions &&
+        !isLoading ? (
         <div>
           <div className="title-sm">
             {t('dataModels.dataModelForm.datasetGroup')}{' '}
           </div>
-          <div className="grey-card">
+          <div className="grey-card" style={{
+            display: "flex",
+            flexDirection: "column"
+          }} >
             <FormSelect
               name="dgId"
               options={dgArrayWithVersions(
@@ -77,9 +80,15 @@ const DataModelForm: FC<DataModelFormType> = ({
               onSelectionChange={(selection) => {
                 handleChange('dgId', selection?.value);
               }}
-              defaultValue={dataModel?.dgId}
+              value={dataModel?.dgId === null && "dataset dosnt exist"}
+              defaultValue={dataModel?.dgId ? dataModel?.dgId : "dataset dosnt exist"}
               error={errors?.dgId}
             />
+            <div>
+              {(type === 'configure') && !dataModel.dgId && <span style={{
+                color: "red", fontSize: "13px"
+              }}>Dataset group does not exist</span>}
+            </div>
           </div>
 
           <div className="title-sm">

--- a/GUI/src/components/molecules/ValidationCriteria/DraggableItem/DraggableItem.tsx
+++ b/GUI/src/components/molecules/ValidationCriteria/DraggableItem/DraggableItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
-import { MdDehaze, MdDeleteOutline  } from 'react-icons/md';
+import { MdDehaze, MdDeleteOutline } from 'react-icons/md';
 import Card from 'components/Card';
 import { FormCheckbox, FormInput, FormSelect } from 'components/FormElements';
 import { ValidationRule } from 'types/datasetGroups';
@@ -21,7 +21,7 @@ const DraggableItem = ({
   setValidationRules,
   validationRuleError,
   validationRules,
-  setValidationRuleError
+  setValidationRuleError,
 }: {
   item: ValidationRule;
   index: number;
@@ -29,7 +29,7 @@ const DraggableItem = ({
   validationRules?: ValidationRule[];
   setValidationRules: React.Dispatch<React.SetStateAction<ValidationRule[]>>;
   validationRuleError?: boolean;
-  setValidationRuleError:React.Dispatch<React.SetStateAction<boolean>>;
+  setValidationRuleError: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const { t } = useTranslation();
   const [, ref] = useDrag({
@@ -69,7 +69,7 @@ const DraggableItem = ({
         item.id === id ? { ...item, fieldName: newValue } : item
       )
     );
-    setValidationRuleError(false);
+    if (newValue?.toLowerCase() === 'rowid') setValidationRuleError(true);
   }, []);
 
   const changeDataType = (id: string | number, value: string) => {
@@ -109,7 +109,7 @@ const DraggableItem = ({
             defaultValue={item.fieldName}
             onBlur={(e) => handleChange(item.id, e.target.value)}
             error={getErrorMessage(item)}
-            aria-autocomplete='none'
+            aria-autocomplete="none"
           />
           <FormSelect
             label={t('datasetGroups.createDataset.datasetType')}
@@ -123,16 +123,14 @@ const DraggableItem = ({
               validationRuleError && !item.dataType ? 'Select a data type' : ''
             }
           />
-          <div
-            className="dragabbleButtonWrapper"
-          >
+          <div className="dragabbleButtonWrapper">
             <Link
               to={''}
               style={{ display: 'flex', gap: '10px', alignItems: 'center' }}
               onClick={() => deleteItem(item.id)}
               className="link"
             >
-              <MdDeleteOutline  />
+              <MdDeleteOutline />
               {t('global.delete')}
             </Link>
             <FormCheckbox
@@ -148,7 +146,7 @@ const DraggableItem = ({
                 width: '150px',
               }}
             />
-            <MdDehaze className="link" size={30} color='#7A7C8A' />
+            <MdDehaze className="link" size={30} color="#7A7C8A" />
           </div>
         </div>
       </Card>

--- a/GUI/src/components/molecules/ValidationCriteria/DraggableItem/DraggableItem.tsx
+++ b/GUI/src/components/molecules/ValidationCriteria/DraggableItem/DraggableItem.tsx
@@ -69,7 +69,6 @@ const DraggableItem = ({
         item.id === id ? { ...item, fieldName: newValue } : item
       )
     );
-    if (newValue?.toLowerCase() === 'rowid') setValidationRuleError(true);
   }, []);
 
   const changeDataType = (id: string | number, value: string) => {
@@ -79,7 +78,7 @@ const DraggableItem = ({
     updatedItems && setValidationRules(updatedItems);
   };
 
-  const getErrorMessage = (item: ValidationRule) => {
+  const getErrorMessage = (item: ValidationRule) => {    
     if (validationRuleError) {
       if (!item.fieldName) {
         return t('datasetGroups.detailedView.fieldName');
@@ -95,7 +94,7 @@ const DraggableItem = ({
         });
       }
     }
-    return '';
+     return '';
   };
 
   return (

--- a/GUI/src/components/molecules/ValidationCriteria/RowsView.tsx
+++ b/GUI/src/components/molecules/ValidationCriteria/RowsView.tsx
@@ -42,9 +42,7 @@ const ValidationCriteriaRowsView: FC<
     );
 
     if (
-      isFieldNameExisting(validationRules, newValue) ||
-      newValue?.toLowerCase() === 'rowid'
-    ) {
+      isFieldNameExisting(validationRules, newValue)) {
       setValidationRuleError(true);
     }
   };

--- a/GUI/src/components/molecules/ValidationCriteria/RowsView.tsx
+++ b/GUI/src/components/molecules/ValidationCriteria/RowsView.tsx
@@ -41,10 +41,11 @@ const ValidationCriteriaRowsView: FC<
       )
     );
 
-    if (isFieldNameExisting(validationRules, newValue)) {
+    if (
+      isFieldNameExisting(validationRules, newValue) ||
+      newValue?.toLowerCase() === 'rowid'
+    ) {
       setValidationRuleError(true);
-    } else {
-      setValidationRuleError(false);
     }
   };
 
@@ -73,6 +74,8 @@ const ValidationCriteriaRowsView: FC<
   };
 
   const getErrorMessage = (item: ValidationRule) => {
+    console.log(validationRuleError);
+
     if (validationRuleError) {
       if (!item.fieldName) {
         return t('datasetGroups.detailedView.fieldName');
@@ -97,7 +100,7 @@ const ValidationCriteriaRowsView: FC<
   };
 
   return (
-    <div className='m--16'>
+    <div className="m--16">
       {validationRules?.map((item, index) => (
         <div
           key={item.id}

--- a/GUI/src/pages/DataModels/ConfigureDataModel.tsx
+++ b/GUI/src/pages/DataModels/ConfigureDataModel.tsx
@@ -54,7 +54,7 @@ const ConfigureDataModel: FC<ConfigureDataModelType> = ({
   const [modalType, setModalType] = useState('');
   const [modalTitle, setModalTitle] = useState<string>('');
   const [modalDiscription, setModalDiscription] = useState<string>('');
-  const modalFunciton = useRef(() => {});
+  const modalFunciton = useRef(() => { });
   const { isLoading } = useQuery(
     dataModelsQueryKeys.GET_META_DATA(id),
     () => getMetadata(id),
@@ -253,7 +253,7 @@ const ConfigureDataModel: FC<ConfigureDataModelType> = ({
 
         <Card>
           <div
-           className='metadata-card'
+            className='metadata-card'
           >
             <div>
               <p>{t('dataModels.configureDataModel.retrainCard')}</p>
@@ -290,6 +290,7 @@ const ConfigureDataModel: FC<ConfigureDataModelType> = ({
           {t('dataModels.configureDataModel.deleteModal')}
         </Button>
         <Button
+          disabled={!dataModel.dgId || dataModel.dgId === 0}
           onClick={() =>
             openModal(
               t('dataModels.configureDataModel.confirmRetrainDesc'),
@@ -318,13 +319,13 @@ const ConfigureDataModel: FC<ConfigureDataModelType> = ({
           <div className="flex-grid">
             <Button
               appearance={ButtonAppearanceTypes.SECONDARY}
-              onClick={()=>setModalOpen(false)}
+              onClick={() => setModalOpen(false)}
             >
               {t('global.cancel')}
             </Button>
             {modalType === 'retrain' ? (
               <Button
-                disabled={retrainDataModelMutation.isLoading}
+                disabled={retrainDataModelMutation.isLoading || !dataModel.dgId || dataModel.dgId === 0}
                 showLoadingIcon={retrainDataModelMutation.isLoading}
                 onClick={() => modalFunciton.current()}
               >

--- a/GUI/src/pages/DataModels/index.tsx
+++ b/GUI/src/pages/DataModels/index.tsx
@@ -158,7 +158,7 @@ const DataModels: FC = () => {
                             datasetGroupName={dataset?.connectedDgName}
                             version={`V${dataset?.majorVersion}.${dataset?.minorVersion}`}
                             isLatest={dataset.latest}
-                            dgVersion={`V${dataset?.connectedDgMajorVersion}.${dataset?.connectedDgMinorVersion}${dataset?.connectedDgPatchVersion}`}
+                            dgVersion={`V${dataset?.connectedDgMajorVersion}.${dataset?.connectedDgMinorVersion}.${dataset?.connectedDgPatchVersion}`}
                             lastTrained={dataset?.lastTrainedTimestamp}
                             trainingStatus={dataset.trainingStatus}
                             platform={dataset?.deploymentEnv}
@@ -331,7 +331,7 @@ const DataModels: FC = () => {
                             datasetGroupName={dataset?.connectedDgName}
                             version={`V${dataset?.majorVersion}.${dataset?.minorVersion}`}
                             isLatest={dataset.latest}
-                            dgVersion={`V${dataset?.connectedDgMajorVersion}.${dataset?.connectedDgMinorVersion}${dataset?.connectedDgPatchVersion}`}
+                            dgVersion={`V${dataset?.connectedDgMajorVersion}.${dataset?.connectedDgMinorVersion}.${dataset?.connectedDgPatchVersion}`}
                             lastTrained={dataset?.lastTrainedTimestamp}
                             trainingStatus={dataset.trainingStatus}
                             platform={dataset?.deploymentEnv}

--- a/GUI/src/pages/DatasetGroups/CreateDatasetGroup.tsx
+++ b/GUI/src/pages/DatasetGroups/CreateDatasetGroup.tsx
@@ -54,7 +54,7 @@ const CreateDatasetGroup: FC = () => {
   const [validationErrorType, setValidationErrorType] =
     useState<ValidationErrorTypes>(ValidationErrorTypes.NULL);
 
-  const validateData = useCallback(() => {
+  const validateData = useCallback(() => {    
     setNodesError(validateClassHierarchy(nodes));
     setDatasetNameError(!datasetName);
     setValidationRuleError(validateValidationRules(validationRules));

--- a/GUI/src/pages/DatasetGroups/ViewDatasetGroup.tsx
+++ b/GUI/src/pages/DatasetGroups/ViewDatasetGroup.tsx
@@ -209,16 +209,34 @@ const ViewDatasetGroup: FC<PropsWithChildren<Props>> = ({ dgId, setView }) => {
     mutationFn: (data: PatchPayLoad) => patchUpdate(data),
     onSuccess: async () => {
       await queryClient.invalidateQueries(datasetQueryKeys.GET_DATA_SETS());
+
       open({
-        title: t('datasetGroups.detailedView.patchDataUnsuccessfulTitle') ?? '',
+        title: t('datasetGroups.detailedView.validationInitiatedTitle') ?? '',
         content: (
-          <p>
-            {t('datasetGroups.detailedView.patchDataUnsuccessfulDesc') ?? ''}
-          </p>
+          <p>{t('datasetGroups.detailedView.validationInitiatedDesc') ?? ''}</p>
+        ),
+        footer: (
+          <div className="flex-grid">
+            <Button
+              appearance={ButtonAppearanceTypes.SECONDARY}
+              onClick={() => {
+                close();
+                setView(DatasetViewEnum.LIST);
+              }}
+            >
+              {t('global.cancel')}
+            </Button>
+            <Button
+              onClick={() => {
+                navigate('/validation-sessions');
+                close();
+              }}
+            >
+              {t('datasetGroups.detailedView.viewValidations') ?? ''}
+            </Button>
+          </div>
         ),
       });
-      close();
-      setView(DatasetViewEnum.LIST);
     },
     onError: () => {
       handleCloseModals();

--- a/GUI/src/pages/DatasetGroups/index.tsx
+++ b/GUI/src/pages/DatasetGroups/index.tsx
@@ -14,6 +14,7 @@ import { datasetQueryKeys } from 'utils/queryKeys';
 import { DatasetViewEnum } from 'enums/datasetEnums';
 import CircularSpinner from 'components/molecules/CircularSpinner/CircularSpinner';
 import NoDataView from 'components/molecules/NoDataView';
+import { ButtonAppearanceTypes } from 'enums/commonEnums';
 
 const DatasetGroups: FC = () => {
   const { t } = useTranslation();
@@ -159,11 +160,11 @@ const DatasetGroups: FC = () => {
                     },
                     {
                       label: t('datasetGroups.sortOptions.createdDateDesc'),
-                      value: 'created_timestamp desc',
+                      value: 'last_updated_timestamp desc',
                     },
                     {
                       label: t('datasetGroups.sortOptions.createdDateAsc'),
-                      value: 'created_timestamp asc',
+                      value: 'last_updated_timestamp asc',
                     },
                   ]}
                   onSelectionChange={(selection) =>
@@ -192,6 +193,7 @@ const DatasetGroups: FC = () => {
                       sort: 'last_updated_timestamp desc',
                     });
                   }}
+                  appearance={ButtonAppearanceTypes.SECONDARY}
                 >
                   {t('global.reset')}
                 </Button>

--- a/GUI/src/pages/DatasetGroups/index.tsx
+++ b/GUI/src/pages/DatasetGroups/index.tsx
@@ -160,10 +160,18 @@ const DatasetGroups: FC = () => {
                     },
                     {
                       label: t('datasetGroups.sortOptions.createdDateDesc'),
-                      value: 'last_updated_timestamp desc',
+                      value: 'created_timestamp desc',
                     },
                     {
                       label: t('datasetGroups.sortOptions.createdDateAsc'),
+                      value: 'created_timestamp asc',
+                    },
+                    {
+                      label: t('datasetGroups.sortOptions.lastUpdatedDateDesc'),
+                      value: 'last_updated_timestamp desc',
+                    },
+                    {
+                      label: t('datasetGroups.sortOptions.lastUpdatedDateAsc'),
                       value: 'last_updated_timestamp asc',
                     },
                   ]}

--- a/GUI/src/utils/datasetGroupsUtils.ts
+++ b/GUI/src/utils/datasetGroupsUtils.ts
@@ -88,7 +88,7 @@ export const validateClassHierarchy = (data: Class[]) => {
 
 export const validateValidationRules = (data: ValidationRule[] | undefined) => {
   for (let item of data) {
-    if (item.fieldName === '' || item.dataType === '') {
+    if (item.fieldName === '' || item.dataType === '' || item.fieldName.toLowerCase() === 'rowid') {
       return true;
     }
   }

--- a/GUI/translations/en/common.json
+++ b/GUI/translations/en/common.json
@@ -153,7 +153,9 @@
       "datasetAsc":"Dataset Group Name A-Z",
       "datasetDesc":"Dataset Group Name Z-A",
       "createdDateAsc":"Created Date Oldest First",
-      "createdDateDesc":"Created Date Latest First"
+      "createdDateDesc":"Created Date Latest First",
+      "lastUpdatedDateAsc":"Last Updated Date Oldest First",
+      "lastUpdatedDateDesc":"Last Updated Date Latest First"
     },
     "table": {
       "group": "Dataset Group",

--- a/GUI/translations/et/common.json
+++ b/GUI/translations/et/common.json
@@ -153,7 +153,9 @@
       "datasetAsc": "Andmestiku Grupi Nimi A-Z",
       "datasetDesc": "Andmestiku Grupi Nimi Z-A",
       "createdDateAsc": "Loomise Kuupäev Vanaimene Esiteks",
-      "createdDateDesc": "Loomise Kuupäev Uuemaine Esiteks"
+      "createdDateDesc": "Loomise Kuupäev Uuemaine Esiteks",
+      "lastUpdatedDateAsc":"Viimati uuendatud kuupäev, vanim esmalt",
+      "lastUpdatedDateDesc":"Viimati uuendatud kuupäev, uusim esmalt"
     },
     "table": {
       "group": "Andmestiku Grupp",

--- a/dataset-processor/dataset_validator.py
+++ b/dataset-processor/dataset_validator.py
@@ -18,7 +18,7 @@ class DatasetValidator:
             metadata = self.get_datagroup_metadata(newDgId, cookie)
             if not metadata:
                 return self.generate_response(False, MSG_REQUEST_FAILED.format("Metadata"), None)
-            session_id = self.create_progress_session(metadata, cookie)
+            session_id = self.create_progress_session(metadata, cookie, False)
             print(f"Progress Session ID : {session_id}")
             if not session_id:
                 return self.generate_response(False, MSG_REQUEST_FAILED.format("Progress session creation"), None)
@@ -27,7 +27,7 @@ class DatasetValidator:
             if not metadata:
                 return self.generate_response(False, MSG_REQUEST_FAILED.format("Metadata"), None)
 
-            session_id = self.create_progress_session(metadata, cookie)
+            session_id = self.create_progress_session(metadata, cookie, True)
             print(f"Progress Session ID : {session_id}")
             if not session_id:
                 return self.generate_response(False, MSG_REQUEST_FAILED.format("Progress session creation"), None)
@@ -381,8 +381,13 @@ class DatasetValidator:
             print(MSG_REQUEST_FAILED.format("Metadata fetch"))
             return None
 
-    def create_progress_session(self, metadata, cookie):
+    def create_progress_session(self, metadata, cookie, patch_update_needed):
         print(f"METADATA : >>>>>>>>>> {metadata}")
+        if patch_update_needed:
+            patch_number = int(metadata['response']['data'][0]['patchVersion'])+1
+        else:
+            patch_number = int(metadata['response']['data'][0]['patchVersion'])
+
         url = CREATE_PROGRESS_SESSION_URL
         headers = {'Content-Type': 'application/json', 'Cookie': cookie}
         payload = {
@@ -390,7 +395,7 @@ class DatasetValidator:
             'groupName': metadata['response']['data'][0]['name'],
             'majorVersion': metadata['response']['data'][0]['majorVersion'],
             'minorVersion': metadata['response']['data'][0]['minorVersion'],
-            'patchVersion': metadata['response']['data'][0]['patchVersion'],
+            'patchVersion': patch_number,
             'latest': metadata['response']['data'][0]['latest']
         }
 


### PR DESCRIPTION
### Issue Summary & Fixes Implemented
**Issue #164: Allowing 'rowid' as a Field Name**

- Description: Users were able to set 'rowid' as a field name, which should not be allowed.

- Steps to Reproduce:

  - Open Settings for a dataset group.
  - Go to Field Name.
  - Edit field name to 'rowid' and click 'Save'.

- Expected Result: An error message should be displayed, and the action should be blocked.

- Actual Result: 'rowid' was accepted as a field name.

- **Fix Implemented**: Upon the user entering 'rowid' as the field name, and clicking on save dataset. warning message will be displayed, and the 'Save' action won't be executed until the rowid field name is removed.

**Issue #163: Reset Button Color**

- Description: The reset button's appearance did not clearly indicate its intended function, leading to user confusion.
- **Fix Implemented**: The color of the reset button has been changed to secondary red to improve visibility and clarify its purpose.

**Issue #162: Created Date and Modified Date Filtering**

- Description: The filtering by created date (latest first or oldest first) and modified date did not function as expected.
- Steps to Reproduce:
  - Pick Created Date Latest First or Oldest First.
  - Click on Search.
- Expected Result: All results should be filtered according to the 'Created Date' or 'Modified Date'.
- Actual Result: Results were not properly filtered.
- **Fix Implemented**: Added support for both 'Created Date' (latest first & oldest first) and 'Modified Date' (latest first & oldest first) ordering. Users can now easily find both the latest created or modified items as needed.